### PR TITLE
Updates for _example/main.go

### DIFF
--- a/_examples/main.go
+++ b/_examples/main.go
@@ -10,10 +10,10 @@ import (
 
 func main() {
 	o := &jail.Opts{
-		Path:     "/zroot/jails/build",
+		Path:     "/zroot/jails/build", //Make sure this directory exists
 		Name:     "jailname",
 		Hostname: "hostname",
-		IP4:      "192.168.0.200",
+		IP4:      "192.168.0.200/24",
 		Chdir:    true,
 	}
 	jid, err := jail.Jail(o)


### PR DESCRIPTION
I ran into 2 situations while running this example.
1- I was getting the following error:
    `invalid CIDR address: 192.168.0.200`
   By providing a CIDR '192.168.0.200/24' I didn't get the error any more.
2- I had to created the directory "/zroot/jails/build" for the code to run without errors. 

I was going to propose adding an additional check from the `syscall.Syscall(sysJail....` call.
I'll submit a PR for that.