### PR TITLE
Check for missing directory error condition.

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -29,6 +29,10 @@ const (
 
 	// ErrjailNoFreeJIDFound [EAGAIN] No free JID could be found.
 	ErrjailNoFreeJIDFound = eagain
+
+        // ErrJailNoSuchFileDirectory [ENOENT] No such file or directory.  A component of a specified pathname
+        // did not exist, or the pathname was   an empty string.
+        ErrJailNoSuchFileDirectory = enoent
 )
 
 // The jail_set() system call will fail with one of the below errors

--- a/jail.go
+++ b/jail.go
@@ -144,6 +144,8 @@ func Jail(o *Opts) (int, error) {
 			return 0, fmt.Errorf("invalid version: %d", e1)
 		case ErrjailNoFreeJIDFound:
 			return 0, fmt.Errorf("no free JID found: %d", e1)
+                case ErrJailNoSuchFileDirectory:
+                        return 0, fmt.Errorf("No such file or directory: %s\n", o.Path)
 		}
 		return 0, fmt.Errorf("%d", e1)
 	}


### PR DESCRIPTION
Adds condition to check for missing directory error returned from `syscall.Syscall(sysJail...)` .