### PR TITLE
golang.org/x/sys/unix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ _testmain.go
 
 _examples/_examples
 .vscode
+*.code-workspace

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/briandowns/jail
 
 go 1.19
+
+require golang.org/x/sys v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
+golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/jail_test.go
+++ b/jail_test.go
@@ -2,8 +2,9 @@ package jail
 
 import (
 	"reflect"
-	"syscall"
 	"testing"
+
+	"golang.org/x/sys/unix"
 )
 
 func TestOpts_validate(t *testing.T) {
@@ -166,7 +167,7 @@ func TestGet(t *testing.T) {
 func Test_getSet(t *testing.T) {
 	type args struct {
 		call  int
-		iov   syscall.Iovec
+		iov   unix.Iovec
 		flags uintptr
 	}
 	tests := []struct {


### PR DESCRIPTION
Syscall has been deprecated, the new go library to use syscalls is golang.org/x/sys/unix.

More info: https://go.googlesource.com/proposal/+/refs/heads/master/design/freeze-syscall.md