### PR TITLE
Fix a small typo in _examples/basic/main.go

### DIFF
--- a/_examples/basic/main.go
+++ b/_examples/basic/main.go
@@ -24,7 +24,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	fmt.Printf("JID: %d - / director listing in jail", jid)
+	fmt.Printf("JID: %d - / directory listing in jail", jid)
 
 	// here so a `jls` can be ran seperately to see that the jail is running
 	time.Sleep(30 * time.Second)


### PR DESCRIPTION
Hey :wave: 

I have started to learn Go, and came across your project. Very cool!
I noticed a very small typo in one of the examples. Maybe this PR helps.
Thanks.