### PR TITLE
Fix jail.{Name,Get}

### DIFF
--- a/jail_test.go
+++ b/jail_test.go
@@ -167,7 +167,8 @@ func TestGet(t *testing.T) {
 func Test_getSet(t *testing.T) {
 	type args struct {
 		call  int
-		iov   unix.Iovec
+		iov   []unix.Iovec
+		keep  []interface{}
 		flags uintptr
 	}
 	tests := []struct {
@@ -179,7 +180,7 @@ func Test_getSet(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := getSet(tt.args.call, tt.args.iov, tt.args.flags); (err != nil) != tt.wantErr {
+			if err := getSet(tt.args.call, tt.args.iov, tt.args.keep, tt.args.flags); (err != nil) != tt.wantErr {
 				t.Errorf("getSet() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
I confirmed both functions were broken locally.

The jail_get(2) syscall expects a pair of iovec objects: one for the key, 
and another for the value. We happened to include only a single iovec 
(for the key), and not the other half of the pair (for the value).

The second argument to jail_get(2) - niov - that we passed was always 
zero as well, and this is incorrect. It should instead be equal to the 
number of iovec objects we have given as arguments.

Fix #9 